### PR TITLE
fix wiotp out handling of format in msg

### DIFF
--- a/application/wiotp.js
+++ b/application/wiotp.js
@@ -258,7 +258,7 @@ module.exports = function(RED) {
 
         this.deviceType = n.deviceType;
         this.deviceId = n.deviceId;
-        this.format = n.format || "json";
+        this.format = n.format;
         this.event = n.event;
 
         if (!isQuickstart) {


### PR DESCRIPTION
wiotp out nodes should be able to handle a custom format passed in the incoming message.
If the Format field of a wiotp out node is left empty, the value should be taken from the .format field of the incoming msg.
This logic is implemented in line 281, where:
- node.format would be taken; missing that, 
- msg.format would be taken; missing that,
- json would be the default.
However, line 261 will set node.format to "json" if the format field is left empty in the configuration.
Just drop this default logic and let it be handled later where it belongs.

Fixes #7.